### PR TITLE
Update dependencies (Gemnasium auto-update a26cd958eb7c89d95c184de91b0bcca1a2029b66)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,9 +75,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.4)
-    autoprefixer-rails (6.6.1)
+    autoprefixer-rails (6.7.5)
       execjs
-    builder (3.2.2)
+    builder (3.2.3)
     climate_control (0.1.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
@@ -90,13 +90,13 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.4)
+    concurrent-ruby (1.0.5)
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.7.0)
-    faker (1.7.2)
+    faker (1.7.3)
       i18n (~> 0.5)
-    faraday (0.10.1)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     favicon_maker (1.3.1)
       docile (~> 1.1)
@@ -118,12 +118,12 @@ GEM
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
-    i18n (0.7.0)
+    i18n (0.8.1)
     jquery-rails (4.2.2)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.0.2)
+    json (2.0.3)
     kgio (2.11.0)
     libv8 (3.16.14.17)
     loofah (2.0.3)
@@ -190,10 +190,10 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sentry-raven (2.3.0)
+    sentry-raven (2.3.1)
       faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.7.0)
-    simplecov (0.12.0)
+    simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -210,11 +210,11 @@ GEM
       libv8 (~> 3.16.14.15)
       ref
     thor (0.19.4)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tilt (2.0.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (3.0.4)
+    uglifier (3.1.0)
       execjs (>= 0.3.0, < 3)
     unicorn (5.2.0)
       kgio (~> 2.6)
@@ -254,4 +254,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
Update dependencies:
simplecov: 0.12.0 => 0.13.0
json: 2.0.2 => 2.0.3
faraday: 0.10.1 => 0.11.0
i18n: 0.7.0 => 0.8.1
uglifier: 3.0.4 => 3.1.0
builder: 3.2.2 => 3.2.3
faker: 1.7.2 => 1.7.3
thread_safe: 0.3.5 => 0.3.6
sentry-raven: 2.3.0 => 2.3.1
autoprefixer-rails: 6.6.1 => 6.7.5
concurrent-ruby: 1.0.4 => 1.0.5