### PR TITLE
:whale: deploy with Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM ruby:2.4
-RUN apt-get update && apt-get -y install nodejs
+RUN apt-get update && apt-get -y install nodejs git
 RUN groupadd -r app && useradd -r -d /app -g app app
 COPY . /app
 WORKDIR /app
-ENV RAILS_ENV=production
-VOLUME var
 RUN chown -R app:app /app
 USER app
 RUN bundle install && bundle exec rake assets:precompile
-CMD bundle exec unicorn
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["rails", "server", "-p", "8080"]
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ruby:2.4
 RUN apt-get update && apt-get -y install nodejs git
-COPY . /app
 WORKDIR /app
+COPY Gemfile /app
+COPY Gemfile.lock /app
 VOLUME /app/public/system
 RUN bundle install
+COPY . /app
 RUN bundle exec rake assets:precompile
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["rails", "server", "-p", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM ruby:2.4
 RUN apt-get update && apt-get -y install nodejs git
-RUN groupadd -r app && useradd -r -d /app -g app app
 COPY . /app
 WORKDIR /app
-RUN chown -R app:app /app
-USER app
+VOLUME /app/public/system
 RUN bundle install && bundle exec rake assets:precompile
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["rails", "server", "-p", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ RUN apt-get update && apt-get -y install nodejs git
 COPY . /app
 WORKDIR /app
 VOLUME /app/public/system
-RUN bundle install && bundle exec rake assets:precompile
+RUN bundle install
+RUN bundle exec rake assets:precompile
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["rails", "server", "-p", "8080"]
 EXPOSE 8080

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,3 +1,6 @@
+FROM chaosdorf/mete as assets
+
+
 FROM nginx:alpine
 ADD nginx.conf /etc/nginx/nginx.conf
-ADD public /usr/share/nginx/html/public
+COPY --from=assets /app/public /usr/share/nginx/html/public

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+ADD nginx.conf /etc/nginx/nginx.conf
+ADD public /usr/share/nginx/html/public

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem "codeclimate-test-reporter", '~> 1', group: :test, require: nil
 # gem 'debugger'
 #
 #
+gem 'sentry-raven'
+
 group :development do
   gem 'faker'
   gem 'rails-perftest', :github => 'rails/rails-perftest'
@@ -53,6 +55,5 @@ end
 
 group :production do
   gem 'SyslogLogger'
-  gem 'sentry-raven'
   gem 'pg'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,6 @@ gem 'sass-rails'
 gem 'coffee-rails'
 gem 'bootstrap-sass', :github => 'thomas-mcdonald/bootstrap-sass'
 
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'therubyracer', :platforms => :ruby
 gem 'execjs'
 
 gem 'uglifier', '>= 1.0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,6 @@ gem 'sass-rails'
 gem 'coffee-rails'
 gem 'bootstrap-sass', :github => 'thomas-mcdonald/bootstrap-sass'
 
-gem 'execjs'
-
 gem 'uglifier', '>= 1.0.3'
 
 gem 'jquery-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,10 @@ gem 'sass-rails'
 gem 'coffee-rails'
 gem 'bootstrap-sass', :github => 'thomas-mcdonald/bootstrap-sass'
 
+# See https://github.com/sstephenson/execjs#readme for more supported runtimes
+gem 'therubyracer', :platforms => :ruby
+gem 'execjs'
+
 gem 'uglifier', '>= 1.0.3'
 
 gem 'jquery-rails'
@@ -26,7 +30,7 @@ gem 'formtastic-bootstrap', :github => 'nickl-/formtastic-bootstrap3', :branch =
 gem 'bootswatch-rails', :github => 'log0ymxm/bootswatch-rails'
 gem 'favicon_maker'
 gem 'mini_magick', :github => 'minimagick/minimagick'
-gem 'unicorn'
+gem 'puma'
 gem 'autoprefixer-rails'
 gem 'rails-controller-testing'
 
@@ -52,4 +56,5 @@ end
 group :production do
   gem 'SyslogLogger'
   gem 'sentry-raven'
+  gem 'pg'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,6 @@ DEPENDENCIES
   bootswatch-rails!
   codeclimate-test-reporter (~> 1)
   coffee-rails
-  execjs
   faker
   favicon_maker
   formtastic
@@ -264,4 +263,4 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
-    libv8 (3.16.14.19)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -188,7 +187,6 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    ref (2.0.0)
     ruby-prof (0.16.2)
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
@@ -222,9 +220,6 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
     temple (0.8.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -266,7 +261,6 @@ DEPENDENCIES
   sentry-raven
   spring
   sqlite3
-  therubyracer
   uglifier (>= 1.0.3)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
-    kgio (2.11.0)
+    libv8 (3.16.14.19)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -152,6 +152,8 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
+    pg (0.21.0)
+    puma (3.10.0)
     rack (2.0.3)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -182,11 +184,11 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    raindrops (0.19.0)
     rake (12.1.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    ref (2.0.0)
     ruby-prof (0.16.2)
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
@@ -220,6 +222,9 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
     temple (0.8.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -227,9 +232,6 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    unicorn (5.3.1)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -244,6 +246,7 @@ DEPENDENCIES
   bootswatch-rails!
   codeclimate-test-reporter (~> 1)
   coffee-rails
+  execjs
   faker
   favicon_maker
   formtastic
@@ -253,6 +256,8 @@ DEPENDENCIES
   jquery-rails
   mini_magick!
   paperclip
+  pg
+  puma
   rails (~> 5)
   rails-controller-testing
   rails-perftest!
@@ -261,8 +266,8 @@ DEPENDENCIES
   sentry-raven
   spring
   sqlite3
+  therubyracer
   uglifier (>= 1.0.3)
-  unicorn
 
 BUNDLED WITH
-   1.13.6
+   1.15.4

--- a/app/controllers/barcodes_controller.rb
+++ b/app/controllers/barcodes_controller.rb
@@ -14,7 +14,7 @@ class BarcodesController < ApplicationController
     if params.key?(:drink)
       @barcode.drink = params[:drink]
     end
-    @drinks = Drink.order(active: :desc).order("name COLLATE nocase")
+    @drinks = Drink.order(active: :desc).order_by_name_asc
     # new.html.haml
   end
   

--- a/app/controllers/drinks_controller.rb
+++ b/app/controllers/drinks_controller.rb
@@ -1,8 +1,12 @@
 class DrinksController < ApplicationController
   # GET /drinks
   def index
-    @drinks = Drink.order(active: :desc).order("name COLLATE nocase")
     # index.html.haml
+    @drinks = Drink.order(active: :desc, name: :asc)
+    respond_to do |format|
+      format.html # index.html.erb
+      format.json { render json: @drinks }
+    end
   end
 
   # GET /drinks/1

--- a/app/controllers/drinks_controller.rb
+++ b/app/controllers/drinks_controller.rb
@@ -1,12 +1,8 @@
 class DrinksController < ApplicationController
   # GET /drinks
   def index
-    # index.html.haml
     @drinks = Drink.order(active: :desc, name: :asc)
-    respond_to do |format|
-      format.html # index.html.erb
-      format.json { render json: @drinks }
-    end
+    # index.html.haml
   end
 
   # GET /drinks/1

--- a/app/controllers/drinks_controller.rb
+++ b/app/controllers/drinks_controller.rb
@@ -1,7 +1,7 @@
 class DrinksController < ApplicationController
   # GET /drinks
   def index
-    @drinks = Drink.order(active: :desc, name: :asc)
+    @drinks = Drink.order(active: :desc).order_by_name_asc
     # index.html.haml
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,17 +1,25 @@
 class UsersController < ApplicationController
   include ApplicationHelper
-  
+
   # GET /users
   def index
-    @users = User.order(active: :desc).order("name COLLATE nocase")
+    @users = User.order(active: :desc, name: :asc)
     # index.html.haml
+    respond_to do |format|
+      format.html # index.html.erb
+      format.json { render json: @users }
+    end
   end
 
   # GET /users/1
   def show
     @user = User.find(params[:id])
-    @drinks = Drink.order(active: :desc).order("name COLLATE nocase")
+    @drinks = Drink.order(active: :desc, name: :asc)
     # show.html.haml
+    respond_to do |format|
+      format.html # show.html.erb
+      format.json { render json: @user }
+    end
   end
 
   # GET /users/new
@@ -84,7 +92,7 @@ class UsersController < ApplicationController
     @drink = Drink.find(params[:drink])
     buy_drink
   end
-  
+
   # POST /users/1/buy_barcode
   def buy_barcode
     @user = User.find(params[:id])
@@ -117,7 +125,7 @@ class UsersController < ApplicationController
   end
 
   private
-  
+
   def buy_drink
     unless @drink.active?
       @drink.active = true
@@ -136,7 +144,7 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name, :email, :balance, :active, :audit, :redirect)
   end
-  
+
   def warn_user_if_audit
     if (@user.audit) then
       flash[:info] = "This transaction has been logged, because you set up your account that way. #{view_context.link_to 'Change?', edit_user_url(@user)}".html_safe

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,10 +5,6 @@ class UsersController < ApplicationController
   def index
     @users = User.order(active: :desc, name: :asc)
     # index.html.haml
-    respond_to do |format|
-      format.html # index.html.erb
-      format.json { render json: @users }
-    end
   end
 
   # GET /users/1
@@ -16,10 +12,6 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @drinks = Drink.order(active: :desc, name: :asc)
     # show.html.haml
-    respond_to do |format|
-      format.html # show.html.erb
-      format.json { render json: @user }
-    end
   end
 
   # GET /users/new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,14 +3,14 @@ class UsersController < ApplicationController
 
   # GET /users
   def index
-    @users = User.order(active: :desc, name: :asc)
+    @users = User.order(active: :desc).order_by_name_asc
     # index.html.haml
   end
 
   # GET /users/1
   def show
     @user = User.find(params[:id])
-    @drinks = Drink.order(active: :desc, name: :asc)
+    @drinks = Drink.order(active: :desc).order_by_name_asc
     # show.html.haml
   end
 

--- a/app/models/barcode.rb
+++ b/app/models/barcode.rb
@@ -1,5 +1,3 @@
 class Barcode < ActiveRecord::Base
-
-  validates_presence_of :drink
-
+  validates_presence_of :id, :drink
 end

--- a/app/models/barcode.rb
+++ b/app/models/barcode.rb
@@ -1,3 +1,5 @@
 class Barcode < ActiveRecord::Base
-  validates_presence_of :id, :drink
+
+  validates_presence_of :drink
+
 end

--- a/app/models/drink.rb
+++ b/app/models/drink.rb
@@ -1,4 +1,7 @@
 class Drink < ActiveRecord::Base
+  scope :order_by_name_asc, -> {
+    order(arel_table['name'].lower.asc)
+  }
 
   validates_presence_of :name, :bottle_size, :price
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ActiveRecord::Base
   validates_presence_of :name
+  scope :order_by_name_asc, -> {
+    order(arel_table['name'].lower.asc)
+  }
 
 
   after_save do |user|

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,10 @@ test:
   timeout: 5000
 
 production:
-  adapter: sqlite3
-  database: var/production.sqlite3
+  adapter: postgresql
+  database: mete
+  host: db
+  username: postgres
+  password: mete
   pool: 5
   timeout: 5000

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,7 +9,7 @@ Mete::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static files server (Apache or nginx will already do this)
-  config.public_file_server.enabled = true
+  config.public_file_server.enabled = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ networks:
   appservers:
 
 volumes:
-  assets:
   system:
   backup:
 
@@ -28,31 +27,37 @@ services:
     restart: on-failure
     networks:
       appservers:
+    depends_on:
+      - db
 
   backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: chaosdorf/mete
-    build: .
     environment:
       RAILS_ENV: production
     build: .
     volumes:
-      - assets:/mete/public/assets
-      - system:/mete/public/system
-    depends_on:
-      - db
+      - system:/app/public/system
     restart: on-failure
     networks:
       appservers:
         aliases:
           - app
+    depends_on:
+      - db
 
   proxy:
-    image: nomaster/nginx-proxy
-    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile-proxy
+    restart: on-failure
     volumes:
-      - assets:/usr/share/nginx/assets:ro
-      - system:/usr/share/nginx/system:ro
+      - system:/usr/share/nginx/html/public/system:ro
     ports:
       - 80:80
     networks:
       appservers:
+    depends_on:
+      - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       appservers:
 
   backend:
-    image: nomaster/mete
+    image: chaosdorf/mete
     build: .
     environment:
       RAILS_ENV: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ networks:
 volumes:
   assets:
   system:
+  backup:
 
 services:
 
@@ -17,6 +18,16 @@ services:
       appservers:
         aliases:
           - db
+
+  db-backup:
+    image: nomaster/postgres-backup
+    environment:
+      PGPASSWORD: mete
+    volumes:
+      - backup:/backup
+    restart: on-failure
+    networks:
+      appservers:
 
   backend:
     image: nomaster/mete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3"
+
+networks:
+  appservers:
+
+volumes:
+  assets:
+  system:
+
+services:
+
+  db:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: mete
+    networks:
+      appservers:
+        aliases:
+          - db
+
+  backend:
+    image: nomaster/mete
+    build: .
+    environment:
+      RAILS_ENV: production
+    build: .
+    volumes:
+      - assets:/mete/public/assets
+      - system:/mete/public/system
+    depends_on:
+      - db
+    restart: on-failure
+    networks:
+      appservers:
+        aliases:
+          - app
+
+  proxy:
+    image: nomaster/nginx-proxy
+    restart: always
+    volumes:
+      - assets:/usr/share/nginx/assets:ro
+      - system:/usr/share/nginx/system:ro
+    ports:
+      - 80:80
+    networks:
+      appservers:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if [ -f /app/tmp/pids/server.pid ]; then
+  rm /app/tmp/pids/server.pid
+fi
+
+bundle exec rake db:migrate 2>/dev/null || bundle exec rake db:setup
+
+exec bundle exec "$@"

--- a/nginx.conf
+++ b/nginx.conf
@@ -24,6 +24,14 @@ http {
       root /usr/share/nginx/html/public;
     }
     location @backend {
+      rewrite ^/audits\.json$ /api/v1/audits.json last;
+      rewrite ^/barcodes\.json$ /api/v1/barcodes.json last;
+      rewrite ^/barcodes/(.*)\.json$ /api/v1/barcodes/$1.json last;
+      rewrite ^/drinks\.json$ /api/v1/drinks.json last;
+      rewrite ^/drinks/(.*)\.json$ /api/v1/drinks/$1.json last;
+      rewrite ^/users\.json$ /api/v1/users.json last;
+      rewrite ^/users/(.*)\.json$ /api/v1/users/$1.json last;
+    
       proxy_pass http://appserver;
     }
     location /ws {

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,38 @@
+error_log stderr;
+events {
+  worker_connections 1024;
+}
+http {
+  client_body_temp_path /tmp/client_body_temp;
+  fastcgi_temp_path /tmp/fastcgi_temp;
+  proxy_temp_path /tmp/proxy_temp;
+  scgi_temp_path /tmp/scgi_temp;
+  uwsgi_temp_path /tmp/uwsgi_temp;
+  upstream appserver {
+    server app:8080;
+  }
+  server {
+    include mime.types;
+    access_log off;
+    listen [::]:80 ipv6only=off;
+    proxy_redirect off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    location / {
+      try_files $uri @backend;
+      root /usr/share/nginx/html/public;
+    }
+    location @backend {
+      proxy_pass http://appserver;
+    }
+    location /ws {
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_set_header CLIENT_IP $remote_addr;
+      proxy_read_timeout 86400;
+      proxy_pass http://appserver;
+    }
+  }
+}


### PR DESCRIPTION
I have made some modifications to deploy mete with `docker-compose`. The HTTP service is always exposed on port 80, so we should make use of a dedicated VM.

Features:
 - move from sqlite to PostgreSQL (for more stability and scalability)
 - switch to Puma webserver (speedier and more recent)
 - backup service that creates database dumps on an hourly basis (very basic implementation)
 - automatic database creation and initialization (see docker-entrypoint.sh)
 
Bugs/Limitations:
 - users and drinks are no longer sorted 'nocase' (PostgreSQL doesn't support it that way) 

Future ideas:
 - create backups from assets as well send backups