### PR TITLE
:bug: fix object import

### DIFF
--- a/app/models/barcode.rb
+++ b/app/models/barcode.rb
@@ -1,3 +1,5 @@
 class Barcode < ActiveRecord::Base
-  validates_presence_of :id, :drink
+
+  validates_presence_of :drink
+
 end


### PR DESCRIPTION
The property `id` is not generated by the client upon object creation.
Thus, it cannot be a requirement.

fixes #52 