### PR TITLE
:bug: fix issues with missing gem in dev environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem "codeclimate-test-reporter", '~> 1', group: :test, require: nil
 # gem 'debugger'
 #
 #
+gem 'sentry-raven'
+
 group :development do
   gem 'faker'
   gem 'rails-perftest', :github => 'rails/rails-perftest'
@@ -51,5 +53,4 @@ end
 
 group :production do
   gem 'SyslogLogger'
-  gem 'sentry-raven'
 end


### PR DESCRIPTION
Rake fails with an an error when the `sentry-raven` gem is not
installed. Moving it to the general list of gems makes it available in
development environment and fixes the issue.

fixes #53 