### PR TITLE
Add Git revision and link to repo in footer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'puma'
 gem 'autoprefixer-rails'
 gem 'rails-controller-testing'
 gem 'bootsnap'
+gem 'git_rev'
 
 gem "codeclimate-test-reporter", '~> 1', group: :test, require: nil
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
     ffi (1.9.25)
     formtastic (2.3.1)
       actionpack (>= 3.0)
+    git_rev (0.1.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     gravatar_image_tag (1.2.0)
@@ -236,6 +237,7 @@ DEPENDENCIES
   favicon_maker
   formtastic
   formtastic-bootstrap!
+  git_rev
   gravatar_image_tag
   haml-rails
   jquery-rails

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -15,6 +15,20 @@ body { padding-top: 70px; }
   padding-left: 3em;
 }
 
+// sticky footer
+html {
+  position: relative;
+  min-height: 100%;
+}
+
+body { margin-bottom: 40px; }
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 40px;
+}
+
 img.disabled {
   //see http://blog.nmsdvid.com/css-filter-property/
   //see http://stackoverflow.com/a/11842712

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
+require 'git_rev'
+
 module ApplicationHelper
+  
+  def get_revision
+    GitRev::Sha.new.short
+  end
 
   def show_amount(price)
     return 'n/a' if price.blank?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -46,6 +46,12 @@
         = render 'flash'
         = yield
 
+    %footer.footer
+      .container
+        %p.text-muted
+          mete
+          = link_to get_revision, "https://github.com/chaosdorf/mete/tree/#{get_revision}"
+
     /
       Javascripts
       \==================================================


### PR DESCRIPTION
I think this would have two benefits:
 * users know which version is running
 * users can open the repository with a single click and eg. create issues

It looks like this: 
![footer](https://user-images.githubusercontent.com/5578100/46571023-e5dec400-c96d-11e8-90d5-7f6314752e15.png)
