### PR TITLE
Allow users to opt-out of overdrafting

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,4 +28,4 @@ if (navigator.userAgent.match(/(ipod|iphone|ipad)/i)) {
 }
 
 //hide notification bars after a few seconds
-$('.alert').delay(10000).fadeOut('slow');
+$('.flash').delay(10000).fadeOut('slow');

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -130,7 +130,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :balance, :active, :audit, :redirect)
+    params.require(:user).permit(:name, :email, :balance, :active, :audit, :redirect, :can_overdraw)
   end
 
   def warn_user_if_audit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,11 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @drinks = Drink.order(active: :desc).order_by_name_asc
+    @drinks_missing = false
+    unless @user.can_overdraw
+      @drinks = @drinks.where(price: (0..@user.balance))
+      @drinks_missing = Drink.where.not(price: (0..@user.balance)).exists?
+    end
     # show.html.haml
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ActiveRecord::Base
   validates_presence_of :name
+  validates :balance, numericality: {greater_than_or_equal_to: 0}, unless: :can_overdraw
   scope :order_by_name_asc, -> {
     order(arel_table['name'].lower.asc)
   }

--- a/app/views/application/_flash.html.haml
+++ b/app/views/application/_flash.html.haml
@@ -1,4 +1,4 @@
 - flash.each do |level, message|
-  .alert(class="alert-#{level}")
+  .flash.alert(class="alert-#{level}")
     %strong= "#{level}!"
     = message

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -7,6 +7,7 @@
     = f.input :active
     = f.input :audit, hint: 'This will create detailed logs about what you buy and deposit. If you uncheck this box, all records will be deleted.'
     = f.input :redirect, hint: "Redirect after buying a drink?"
+    = f.input :can_overdraw, hint: "Allow the balance to go below zero?"
   = f.actions do
     = f.action :submit
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -36,6 +36,12 @@
 
 %hr
 
+- if @drinks_missing
+  .alert.alert-info
+    Some drinks are hidden because their price is higher than your balance
+    and you have disabled overdrawing.
+    = link_to 'Change?', edit_user_url(@user)
+
 .row.drinks
   = render @drinks, :locals => {:user => @user}
 

--- a/db/migrate/20200119134526_add_can_overdraw_to_users.rb
+++ b/db/migrate/20200119134526_add_can_overdraw_to_users.rb
@@ -1,0 +1,10 @@
+class AddCanOverdrawToUsers < ActiveRecord::Migration[5.2]
+  def up
+    add_column :users, :can_overdraw, :boolean, default: true
+    User.all.each { |user| user.can_overdraw = true }
+  end
+  
+  def down
+    remove_column :users, :can_overdraw
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170929201659) do
+ActiveRecord::Schema.define(version: 2020_01_19_134526) do
 
   create_table "audits", force: :cascade do |t|
     t.datetime "created_at"
@@ -21,7 +21,6 @@ ActiveRecord::Schema.define(version: 20170929201659) do
 
   create_table "barcodes", id: :string, force: :cascade do |t|
     t.integer "drink", null: false
-    t.index ["id"], name: "sqlite_autoindex_barcodes_1", unique: true
   end
 
   create_table "drinks", force: :cascade do |t|
@@ -47,6 +46,7 @@ ActiveRecord::Schema.define(version: 20170929201659) do
     t.boolean "active", default: true
     t.boolean "audit", default: false
     t.boolean "redirect", default: true
+    t.boolean "can_overdraw", default: true
   end
 
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,6 +4,7 @@ one:
   name: A
   email: mail@example.net
   balance: 100
+  can_overdraw: false
 
 two:
   name: B

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -98,6 +98,17 @@ class UsersControllerTest < ActionController::TestCase
     assert_redirected_to users(:two)
   end
   
+  test "buy with overdrafting disabled succeed if balance is high enough" do
+    get :buy, params: {id: @user, drink: @drink}
+    assert_redirected_to redirect_path(@user)
+  end
+  
+  test "buy with overdrafting disabled fails if balance is not high enough" do
+    assert_raises ActiveRecord::RecordInvalid do
+      get :payment, params: {id: @user, amount: 200}
+    end
+  end
+  
   test "buy by barcode" do
     assert_difference('Audit.count') do
       post :buy_barcode, params: {id: @user, barcode: @barcode}


### PR DESCRIPTION
To achieve this there's a new user attribute: `can_overdraw`.
This is enabled by default for all new and existing users.
If this is set to false, this user's balance can go below zero.
Drinks are hidden from the user page when their price is higher then the user's balance and the user has `can_overdraw` disabled.

This is not yet fully exposed via the API - the attribute is returned but can't be changed and the validation is still being performed. This has to be added before merging this PR.