### PR TITLE
Fix broken docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This is built automatically on each push to `master`, but should still be stable
 Here's a minimal example using docker-compose:
 
 ```yaml
-version: 3
+version: "3"
 volumes:
   system:
   database:


### PR DESCRIPTION
Using latest docker-compose distributed with manjaro I got the following error:

```
[mop@gustav-theodor kalkspace-mete]$ docker-compose up -d
ERROR: Version in "./docker-compose.yml" is invalid - it should be a string.
```

Fix seems easy enough :D