### PR TITLE
:bug: Use pessimistic locking for users (closes #97)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,19 +12,25 @@ class User < ApplicationRecord
   end
 
   def deposit(amount)
-    self.balance += amount
-    save!
+    with_lock do
+      self.balance += amount
+      save!
+    end
   end
 
   def buy(drink)
-    self.balance -= drink.price
-    @purchased_drink = drink
-    save!
+    with_lock do
+      self.balance -= drink.price
+      @purchased_drink = drink
+      save!
+    end
   end
 
   def payment(amount)
-    self.balance -= amount
-    save!
+    with_lock do
+      self.balance -= amount
+      save!
+    end
   end
 
   def initial


### PR DESCRIPTION
On Postgres, this solves our concurrency bugs with the slight downside
that some concurrent requests may take longer.
On SQLite, this also produces correct results, but some concurrent
requests may error out after hanging for a bit.

I tried modifying the timeouts but this did not seem to have the desired
effect.

I have not been able to write a test (for Rails) to verify whether this does work (or not).
(I do have a simple client using HTTP though.)