### PR TITLE
:bug: Use default Gravatar placeholder

### DIFF
--- a/config/initializers/gravatar_image_tag.rb
+++ b/config/initializers/gravatar_image_tag.rb
@@ -3,6 +3,5 @@
 # see https://github.com/mdeering/gravatar_image_tag
 
 GravatarImageTag.configure do |config|
-  config.default_image = "https://c3fickdistanz.de/gravatar-140.png"
   config.secure = true
 end


### PR DESCRIPTION
We had a custom one based on GitHub's default avatar, but it's down now.
As we haven't been using any GitHub API to display avatars,
it might be the best solution to just use the default Gravatar icon.
Also, we get one less external request that way.