### PR TITLE
Switch to Bootstrap 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sqlite3'
 
 gem 'sassc-rails'
 gem 'coffee-rails'
-gem 'bootstrap', "~> 4"
+gem 'bootstrap', "~> 5"
 
 gem 'uglifier'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,9 +65,9 @@ GEM
       execjs (> 0)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
-    bootstrap (4.6.0)
+    bootstrap (5.0.1)
       autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 1.14.3, < 2)
+      popper_js (>= 2.9.2, < 3)
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
     climate_control (0.2.0)
@@ -159,7 +159,7 @@ GEM
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
     pg (1.2.3)
-    popper_js (1.16.0)
+    popper_js (2.9.2)
     puma (5.3.2)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -251,7 +251,7 @@ DEPENDENCIES
   SyslogLogger
   autoprefixer-rails
   bootsnap
-  bootstrap (~> 4)
+  bootstrap (~> 5)
   codeclimate-test-reporter
   coffee-rails
   faker

--- a/app/assets/stylesheets/bootswatch/slate/_bootswatch.scss
+++ b/app/assets/stylesheets/bootswatch/slate/_bootswatch.scss
@@ -1,8 +1,8 @@
-// Slate 4.0.0
+// Slate 5.0.1
 // Bootswatch
 
 
-// Variables ===================================================================
+// Mixins
 
 @mixin btn-shadow($color){
   @include gradient-y-three-colors(lighten($color, 6%), $color, 60%, darken($color, 4%));
@@ -14,49 +14,49 @@
   filter: none;
 }
 
-// Navbar ======================================================================
+// Navbar
 
 .navbar {
-  border: 1px solid rgba(0, 0, 0, 0.6);
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(0, 0, 0, .6);
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, .3);
 
   .container {
     padding: 0;
   }
 
   .navbar-toggler {
-    border-color: rgba(0, 0, 0, 0.6);
+    border-color: rgba(0, 0, 0, .6);
   }
 
   &-fixed-top {
-    border-width: 0 0 1px 0;
+    border-width: 0 0 1px;
   }
 
   &-fixed-bottom {
-    border-width: 1px 0 0 0;
+    border-width: 1px 0 0;
   }
 
   .nav-link {
     padding: 1rem;
-    border-left: 1px solid rgba(255, 255, 255, 0.1);
-    border-right: 1px solid rgba(0, 0, 0, 0.2);
+    border-left: 1px solid rgba(255, 255, 255, .1);
+    border-right: 1px solid rgba(0, 0, 0, .2);
 
     &:hover,
     &:focus {
       @include btn-shadow-inverse($gray-800);
-      border-left: 1px solid rgba(0, 0, 0, 0.2);
+      border-left: 1px solid rgba(0, 0, 0, .2);
     }
   }
 
   &-brand {
-    padding: 0.75rem 1rem calc(54px - 0.75rem - 30px);
+    padding: .75rem 1rem subtract(24px, .75rem);
     margin-right: 0;
-    border-right: 1px solid rgba(0, 0, 0, 0.2);
+    border-right: 1px solid rgba(0, 0, 0, .2);
   }
 
   .nav-item.active .nav-link {
-    background-color: rgba(0, 0, 0, 0.3);
-    border-left: 1px solid rgba(0, 0, 0, 0.2);
+    background-color: rgba(0, 0, 0, .3);
+    border-left: 1px solid rgba(0, 0, 0, .2);
   }
 
   &-nav .nav-item + .nav-item {
@@ -64,13 +64,13 @@
   }
 
   &.bg-light {
-    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.1);
+    text-shadow: 1px 1px 1px rgba(0, 0, 0, .1);
 
     .nav-link {
       &:hover,
       &:focus {
         @include btn-shadow-inverse($gray-600);
-        border-left: 1px solid rgba(0, 0, 0, 0.2);
+        border-left: 1px solid rgba(0, 0, 0, .2);
       }
     }
   }
@@ -103,15 +103,15 @@
   }
 }
 
-// Buttons =====================================================================
+// Buttons
 
 .btn {
-  border-color: rgba(0, 0, 0, 0.6);
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
+  border-color: rgba(0, 0, 0, .6);
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, .3);
 
   &:not([disabled]):not(.disabled).active,
   &.disabled {
-    border-color: rgba(0, 0, 0, 0.6);
+    border-color: rgba(0, 0, 0, .6);
     box-shadow: none;
   }
 
@@ -120,7 +120,7 @@
   &:not([disabled]):not(.disabled):active,
   &:not([disabled]):not(.disabled):active:hover,
   &:not([disabled]):not(.disabled).active:hover {
-    border-color: rgba(0, 0, 0, 0.6);
+    border-color: rgba(0, 0, 0, .6);
   }
 }
 
@@ -193,6 +193,12 @@
   }
 }
 
+.btn-outline {
+  &-primary {
+    color: $white;
+  }
+}
+
 .btn-link,
 .btn-link:hover {
   border-color: transparent;
@@ -200,121 +206,69 @@
 
 .btn-group,
 .btn-group-vertical {
-
   .btn.active {
-    border-color: rgba(0, 0, 0, 0.6);
+    border-color: rgba(0, 0, 0, .6);
   }
 }
 
-// Typography ==================================================================
+// Typography
 
-h1, h2, h3, h4, h5, h6 {
-  text-shadow: -1px -1px 0 rgba(0, 0, 0, 0.3);
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-shadow: -1px -1px 0 rgba(0, 0, 0, .3);
 }
 
-// Tables ======================================================================
-
-.table {
-  &-success,
-  &-info,
-  &-warning,
-  &-danger {
-    color: #fff;
-  }
-}
-
-.table {
-
-  .thead-dark th {
-    color: $white;
-  }
-
-  &-success {
-    &, > th, > td {
-      background-color: $success;
-    }
-  }
-
-  &-info {
-    &, > th, > td {
-      background-color: $info;
-    }
-  }
-
-  &-danger {
-    &, > th, > td {
-      background-color: $danger;
-    }
-  }
-
-  &-warning {
-    &, > th, > td {
-      background-color: $warning;
-    }
-  }
-
-  &-hover {
-
-    .table-success:hover {
-      &, > th, > td {
-        background-color: darken($success, 5%);
-      }
-    }
-
-    .table-info:hover {
-      &, > th, > td {
-        background-color: darken($info, 5%);
-      }
-    }
-
-    .table-danger:hover {
-      &, > th, > td {
-        background-color: darken($danger, 5%);
-      }
-    }
-
-    .table-warning:hover {
-      &, > th, > td {
-        background-color: darken($warning, 5%);
-      }
-    }
-
-  }
-}
-
-// Forms =======================================================================
+// Forms
 
 legend {
-  color: #fff;
+  color: $white;
 }
 
 .input-group-addon {
   @include btn-shadow($secondary);
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, .3);
   color: $white;
 }
 
-// Navs ========================================================================
+// Navs
 
 .nav-tabs {
+  .nav-link {
+    @include btn-shadow-inverse($gray-800);
+    border: 1px solid rgba(0, 0, 0, .6);
+
+    &:not([disabled]):not(.disabled):hover,
+    &:not([disabled]):not(.disabled):focus,
+    &:not([disabled]):not(.disabled):active,
+    &:not([disabled]):not(.disabled).active {
+      @include btn-shadow($gray-800);
+    }
+
+    &.disabled {
+      border: 1px solid rgba(0, 0, 0, .6);
+    }
+  }
 
   .nav-link,
   .nav-link:hover {
-    color: #fff;
+    color: $white;
   }
 }
 
 .nav-pills {
-
   .nav-link {
     @include btn-shadow($gray-800);
-    border: 1px solid rgba(0, 0, 0, 0.6);
-    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
-    color: #fff;
+    border: 1px solid rgba(0, 0, 0, .6);
+    text-shadow: 1px 1px 1px rgba(0, 0, 0, .3);
+    color: $white;
 
     &:hover {
       @include btn-shadow-inverse($gray-800);
-      border: 1px solid rgba(0, 0, 0, 0.6);
+      border: 1px solid rgba(0, 0, 0, .6);
     }
   }
 
@@ -322,7 +276,7 @@ legend {
   .nav-link:hover {
     background-color: transparent;
     @include btn-shadow-inverse($gray-800);
-    border: 1px solid rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(0, 0, 0, .6);
   }
 
   .nav-link.disabled,
@@ -333,9 +287,8 @@ legend {
 }
 
 .pagination {
-
   .page-link {
-    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
+    text-shadow: 1px 1px 1px rgba(0, 0, 0, .3);
     @include btn-shadow($gray-800);
 
     &:hover {
@@ -354,26 +307,18 @@ legend {
 }
 
 .breadcrumb {
-  border: 1px solid rgba(0, 0, 0, 0.6);
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(0, 0, 0, .6);
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, .3);
   background-color: transparent;
   @include btn-shadow($gray-800);
 
   a,
   a:hover {
-    color: #fff;
+    color: $white;
   }
 }
 
-// Indicators ==================================================================
-
-.alert {
-
-  .close {
-    color: $close-color;
-    text-decoration: none;
-  }
-}
+// Indicators
 
 .alert {
   border: none;
@@ -381,7 +326,7 @@ legend {
 
   a,
   .alert-link {
-    color: #fff;
+    color: $white;
     text-decoration: underline;
   }
 
@@ -393,33 +338,23 @@ legend {
 
   &-light {
     &,
-    & a:not(.btn),
-    & .alert-link {
+    a:not(.btn),
+    .alert-link {
       color: $body-bg;
     }
   }
 }
 
 .badge {
-
-  &-success,
-  &-warning,
-  &-info {
-    color: $white;
+  &.bg-light {
+    color: $dark;
   }
 }
 
-// Progress bars ===============================================================
-
-// Containers ==================================================================
-
-.jumbotron {
-  border: 1px solid rgba(0, 0, 0, 0.6);
-}
+// Containers
 
 .list-group {
-
-  &-item:hover {
+  &-item-action:hover {
     background-color: darken($gray-900, 5%);
   }
 }

--- a/app/assets/stylesheets/bootswatch/slate/_variables.scss
+++ b/app/assets/stylesheets/bootswatch/slate/_variables.scss
@@ -1,5 +1,7 @@
-// Slate 4.0.0
+// Slate 5.0.1
 // Bootswatch
+
+$theme: "slate" !default;
 
 //
 // Color system
@@ -11,10 +13,10 @@ $gray-200: #e9ecef !default;
 $gray-300: #dee2e6 !default;
 $gray-400: #ced4da !default;
 $gray-500: #999 !default;
-$gray-600: #7A8288 !default;
-$gray-700: #52575C !default;
-$gray-800: #3A3F44 !default;
-$gray-900: #272B30 !default;
+$gray-600: #7a8288 !default;
+$gray-700: #52575c !default;
+$gray-800: #3a3f44 !default;
+$gray-900: #272b30 !default;
 $black:    #000 !default;
 
 $blue:    #007bff !default;
@@ -37,6 +39,8 @@ $danger:        $red !default;
 $light:         $gray-200 !default;
 $dark:          $gray-900 !default;
 
+$min-contrast-ratio:   2 !default;
+
 // Body
 
 $body-bg:                   $gray-900 !default;
@@ -48,17 +52,16 @@ $link-color:                $white !default;
 
 // Fonts
 
-$font-size-base:              0.9375rem !default;
-
 // Tables
 
-$table-accent-bg:             rgba($white,.05) !default;
-$table-hover-bg:              rgba($white,.075) !default;
-
-$table-border-color:          rgba($black,.6) !default;
-
+$table-color:                 $white !default;
+$table-accent-bg:             rgba($white, .05) !default;
+$table-hover-bg:              rgba($white, .075) !default;
+$table-border-color:          rgba($black, .6) !default;
 $table-dark-border-color:     $table-border-color !default;
 $table-dark-color:            $white !default;
+
+$table-bg-scale:              0 !default;
 
 // Buttons
 
@@ -69,18 +72,24 @@ $input-btn-padding-x:         1rem !default;
 
 $input-disabled-bg:                     #ccc !default;
 
+$input-color:                       $gray-900 !default;
+
+$form-check-input-bg:                     $white !default;
+
 // Dropdowns
 
 $dropdown-bg:                       $gray-800 !default;
-$dropdown-divider-bg:               rgba($black,.15) !default;
-
+$dropdown-border-color:             rgba($black, .6) !default;
+$dropdown-divider-bg:               rgba($black, .15) !default;
 $dropdown-link-color:               $body-color !default;
 $dropdown-link-hover-color:         $white !default;
 $dropdown-link-hover-bg:            $body-bg !default;
+$dropdown-link-active-color:        $dropdown-link-hover-color !default;
+$dropdown-link-active-bg:           $dropdown-link-hover-bg !default;
 
 // Navs
 
-$nav-tabs-border-color:             rgba($black, 0.6) !default;
+$nav-tabs-border-color:             rgba($black, .6) !default;
 $nav-tabs-link-hover-border-color:  $nav-tabs-border-color !default;
 $nav-tabs-link-active-color:        $white !default;
 $nav-tabs-link-active-border-color: $nav-tabs-border-color !default;
@@ -88,9 +97,7 @@ $nav-tabs-link-active-border-color: $nav-tabs-border-color !default;
 // Navbar
 
 $navbar-padding-y:                  0 !default;
-
 $navbar-dark-hover-color:           $white !default;
-
 $navbar-light-hover-color:          $gray-800 !default;
 $navbar-light-active-color:         $gray-800 !default;
 
@@ -99,26 +106,18 @@ $navbar-light-active-color:         $gray-800 !default;
 
 $pagination-color:                  $white !default;
 $pagination-bg:                     transparent !default;
-$pagination-border-color:           rgba($black, 0.6) !default;
-
+$pagination-border-color:           rgba($black, .6) !default;
 $pagination-hover-color:            $white !default;
 $pagination-hover-bg:               transparent !default;
-$pagination-hover-border-color:     rgba($black, 0.6) !default;
-
+$pagination-hover-border-color:     rgba($black, .6) !default;
 $pagination-active-bg:              transparent !default;
-$pagination-active-border-color:    rgba($black, 0.6) !default;
-
+$pagination-active-border-color:    rgba($black, .6) !default;
 $pagination-disabled-bg:            transparent !default;
-$pagination-disabled-border-color:  rgba($black, 0.6) !default;
-
-
-// Jumbotron
-
-$jumbotron-bg:                      darken($gray-900, 5%) !default;
+$pagination-disabled-border-color:  rgba($black, .6) !default;
 
 // Cards
 
-$card-border-color:                 rgba($black, 0.6) !default;
+$card-border-color:                 rgba($black, .6) !default;
 $card-cap-bg:                       lighten($gray-800, 10%) !default;
 $card-bg:                           lighten($body-bg, 5%) !default;
 
@@ -126,11 +125,18 @@ $card-bg:                           lighten($body-bg, 5%) !default;
 
 $popover-bg:                        lighten($body-bg, 5%) !default;
 
+// Toasts
+
+$toast-background-color:            lighten($body-bg, 5%) !default;
+$toast-border-color:                rgba(0, 0, 0, .2) !default;
+$toast-header-color:                $body-color !default;
+$toast-header-background-color:     $toast-background-color !default;
+$toast-header-border-color:         $toast-border-color !default;
+
 // Modals
 
 $modal-content-bg:                  lighten($body-bg, 5%) !default;
-
-$modal-header-border-color:         rgba(0,0,0,.2) !default;
+$modal-header-border-color:         rgba(0, 0, 0, .2) !default;
 
 // Progress bars
 
@@ -139,18 +145,23 @@ $progress-bar-color:                $gray-600 !default;
 
 // List group
 
+$list-group-color:                  $white !default;
 $list-group-bg:                     lighten($body-bg, 5%) !default;
-$list-group-border-color:           rgba($black, 0.6) !default;
-
+$list-group-border-color:           rgba($black, .6) !default;
 $list-group-hover-bg:               lighten($body-bg, 10%) !default;
 $list-group-active-color:           $white !default;
 $list-group-active-bg:              $list-group-hover-bg !default;
 $list-group-active-border-color:    $list-group-border-color !default;
-
 $list-group-disabled-color:         $gray-700 !default;
-
 $list-group-action-color:           $white !default;
 
 // Breadcrumbs
 
+$breadcrumb-padding-y:              .375rem !default;
+$breadcrumb-padding-x:              .75rem !default;
 $breadcrumb-active-color:           $gray-500 !default;
+$breadcrumb-border-radius:          .25rem !default;
+
+// Code
+
+$pre-color:                         inherit !default;

--- a/app/views/audits/index.html.haml
+++ b/app/views/audits/index.html.haml
@@ -1,17 +1,17 @@
 - model_class = Audit
 
 = form_tag({}, { :class => 'form-horizontal', :method => :get }) do
-  .form-group
+  .mb-3
     = label_tag :start_date, "Show audits from ", class: 'col-form-label'
     .controls
       = select_date @start_date, prefix: :start_date, class: 'form-control'
-  .form-group
+  .mb-3
     = label_tag :end_date, "until", class: 'col-form-label'
     .controls
       = select_date @end_date, prefix: :end_date, class: 'form-control'
   - unless @user.nil?
     %input{:type => "hidden", :name => "user", :value => @user.id}
-  .form-group
+  .mb-3
     .controls
       %button.btn.btn-primary
         Filter

--- a/app/views/audits/index.html.haml
+++ b/app/views/audits/index.html.haml
@@ -33,22 +33,24 @@
     = @user.nil? ? "all users" : "user #{@user.name}"
     \:
 
-%table.table.table-striped.table-bordered.table-sm
-  %tr
-    %th Timestamp
-    %th Amount
-    %th Drink
-  - @audits.each do |audit|
-    - if audit.difference > 0
-      %tr.table-success
-        %td= audit.created_at
-        %td
-          = show_amount audit.difference
-        %td n/a
-    - else
-      %tr.table-error
-        %td= audit.created_at
-        %td
-          = show_amount audit.difference
-        %td
-          = link_to_drink_if_exists audit.drink
+%table.table.table-striped.table-bordered.table-sm.table-dark
+  %thead
+    %tr
+      %th{:scope => "col"} Timestamp
+      %th{:scope => "col"} Amount
+      %th{:scope => "col"} Drink
+  %tbody
+    - @audits.each do |audit|
+      - if audit.difference > 0
+        %tr.table-success
+          %td= audit.created_at
+          %td
+            = show_amount audit.difference
+          %td n/a
+      - else
+        %tr.table-danger
+          %td= audit.created_at
+          %td
+            = show_amount audit.difference
+          %td
+            = link_to_drink_if_exists audit.drink

--- a/app/views/barcodes/index.html.haml
+++ b/app/views/barcodes/index.html.haml
@@ -8,16 +8,16 @@
     Barcodes.
     %small Here they are.
 
-%table.table.table-striped.table-bordered
+%table.table.table-striped.table-bordered.table-dark
   %thead
     %tr
-      %th= model_class.human_attribute_name(:id)
-      %th= model_class.human_attribute_name(:drink)
-      %th Delete?
+      %th{:scope => "col"}= model_class.human_attribute_name(:id)
+      %th{:scope => "col"}= model_class.human_attribute_name(:drink)
+      %th{:scope => "col"} Delete?
   %tbody
     - @barcodes.each do |barcode|
       %tr
-        %td= barcode.id
+        %th{:scope => "row"}= barcode.id
         %td
           = link_to_drink_if_exists barcode.drink
         %td

--- a/app/views/drinks/index.html.haml
+++ b/app/views/drinks/index.html.haml
@@ -8,25 +8,25 @@
     Drinks.
     %small All of them!
 
-%table.table.table-striped.table-bordered
+%table.table.table-striped.table-bordered.table-dark
   %thead
     %tr
-      %th
+      %th{:scope => "col"}
         = model_class.human_attribute_name(:logo)
         %span.small
           (click to edit drink)
-      %th= model_class.human_attribute_name(:name)
-      %th= model_class.human_attribute_name(:bottle_size)
-      %th= model_class.human_attribute_name(:caffeine)
-      %th= model_class.human_attribute_name(:price)
-      %th= model_class.human_attribute_name(:created_at)
+      %th{:scope => "col"}= model_class.human_attribute_name(:name)
+      %th{:scope => "col"}= model_class.human_attribute_name(:bottle_size)
+      %th{:scope => "col"}= model_class.human_attribute_name(:caffeine)
+      %th{:scope => "col"}= model_class.human_attribute_name(:price)
+      %th{:scope => "col"}= model_class.human_attribute_name(:created_at)
   %tbody
     - @drinks.each do |drink|
       %tr
         %td
           = link_to [:edit, drink] do
             = image_tag drink.logo(:thumb), class: drink.active ? "" : "disabled"
-        %td= drink.name
+        %th{:scope => "row"}= drink.name
         %td= drink.bottle_size
         %td= drink.caffeine
         %td= show_amount drink.price

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,20 +24,20 @@
   %body
     %header
       %nav.navbar.navbar-expand-md.navbar-dark.bg-primary.fixed-top( role="navigation" )
-        %button.navbar-toggler( type="buttoon" data-toggle="collapse" data-target=".navbar-ex1-collapse" )
-          %span.sr-only Toggle navigation
-          %span.navbar-toggler-icon
-        = link_to 'MeTe', root_path, :class => 'navbar-brand'
+        .container-fluid
+          %button.navbar-toggler( type="button" data-bs-toggle="collapse" data-bs-target=".navbar-ex1-collapse" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation" )
+            %span.navbar-toggler-icon
+          = link_to 'MeTe', root_path, :class => 'navbar-brand'
 
-        .collapse.navbar-collapse.navbar-ex1-collapse
-          %ul.navbar-nav.mr-auto
-            %li.nav-item= link_to "Users", url_for(controller: 'users'), class: "nav-link"
-            %li.nav-item= link_to "Stats", url_for(controller: 'users', action: 'stats'), class: "nav-link"
-            %li.nav-item= link_to "Audits", url_for(controller: 'audits'), class: "nav-link"
-            %li.nav-item= link_to "Drinks", url_for(controller: 'drinks'), class: "nav-link"
-            %li.nav-item= link_to "Barcodes", url_for(controller: 'barcodes'), class: "nav-link"
-          %ul.navbar-nav
-            = yield :actions
+          .collapse.navbar-collapse.navbar-ex1-collapse.justify-content-between#navbar
+            %ul.navbar-nav.mr-auto
+              %li.nav-item= link_to "Users", url_for(controller: 'users'), class: "nav-link"
+              %li.nav-item= link_to "Stats", url_for(controller: 'users', action: 'stats'), class: "nav-link"
+              %li.nav-item= link_to "Audits", url_for(controller: 'audits'), class: "nav-link"
+              %li.nav-item= link_to "Drinks", url_for(controller: 'drinks'), class: "nav-link"
+              %li.nav-item= link_to "Barcodes", url_for(controller: 'barcodes'), class: "nav-link"
+            %ul.navbar-nav
+              = yield :actions
 
     %article
       .container

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -2,15 +2,15 @@
 
 # Please do not make direct changes to this file!
 # This generator is maintained by the community around simple_form-bootstrap:
-# https://github.com/rafaelfranca/simple_form-bootstrap
+# https://github.com/heartcombo/simple_form-bootstrap
 # All future development, tests, and organization should happen there.
-# Background history: https://github.com/plataformatec/simple_form/issues/1561
+# Background history: https://github.com/heartcombo/simple_form/issues/1561
 
 # Uncomment this and change the path if necessary to include your own
 # components.
-# See https://github.com/plataformatec/simple_form#custom-components
+# See https://github.com/heartcombo/simple_form#custom-components
 # to know more about custom components.
-# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
 
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
@@ -49,7 +49,7 @@ SimpleForm.setup do |config|
   # vertical forms
   #
   # vertical default_wrapper
-  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_form, class: 'mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -57,90 +57,100 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label
+    b.use :label, class: 'form-label'
     b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical input for boolean
-  config.wrappers :vertical_boolean, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_boolean, tag: 'fieldset', class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :form_check_wrapper, tag: 'div', class: 'form-check' do |bb|
+    b.wrapper :form_check_wrapper, class: 'form-check' do |bb|
       bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
       bb.use :label, class: 'form-check-label'
-      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      bb.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      bb.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # vertical input for radio buttons and check boxes
-  config.wrappers :vertical_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', tag: 'fieldset', class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
     b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
       ba.use :label_text
     end
     b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical input for inline radio buttons and check boxes
-  config.wrappers :vertical_collection_inline, item_wrapper_class: 'form-check form-check-inline', item_label_class: 'form-check-label', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_collection_inline, item_wrapper_class: 'form-check form-check-inline', item_label_class: 'form-check-label', tag: 'fieldset', class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
     b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
       ba.use :label_text
     end
     b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical file input
-  config.wrappers :vertical_file, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_file, class: 'mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
     b.optional :minlength
     b.optional :readonly
-    b.use :label
-    b.use :input, class: 'form-control-file', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: 'form-label'
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
+  end
+
+  # vertical select input
+  config.wrappers :vertical_select, class: 'mb-3' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'form-label'
+    b.use :input, class: 'form-select', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical multi select
-  config.wrappers :vertical_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_multi_select, class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label
-    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
-      ba.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label, class: 'form-label'
+    b.wrapper class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
+      ba.use :input, class: 'form-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
     end
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical range input
-  config.wrappers :vertical_range, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_range, class: 'mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :readonly
     b.optional :step
-    b.use :label
-    b.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: 'form-label'
+    b.use :input, class: 'form-range', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
 
   # horizontal forms
   #
   # horizontal default_wrapper
-  config.wrappers :horizontal_form, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_form, class: 'row mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -149,94 +159,103 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
     b.use :label, class: 'col-sm-3 col-form-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
       ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal input for boolean
-  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_boolean, class: 'row mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper tag: 'label', class: 'col-sm-3' do |ba|
-      ba.use :label_text
-    end
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |wr|
-      wr.wrapper :form_check_wrapper, tag: 'div', class: 'form-check' do |bb|
+    b.wrapper :grid_wrapper, class: 'col-sm-9 offset-sm-3' do |wr|
+      wr.wrapper :form_check_wrapper, class: 'form-check' do |bb|
         bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
         bb.use :label, class: 'form-check-label'
-        bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-        bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+        bb.use :full_error, wrap_with: { class: 'invalid-feedback' }
+        bb.use :hint, wrap_with: { class: 'form-text' }
       end
     end
   end
 
   # horizontal input for radio buttons and check boxes
-  config.wrappers :horizontal_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', class: 'row mb-3' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'col-sm-3 col-form-label pt-0'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
       ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal input for inline radio buttons and check boxes
-  config.wrappers :horizontal_collection_inline, item_wrapper_class: 'form-check form-check-inline', item_label_class: 'form-check-label', tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_collection_inline, item_wrapper_class: 'form-check form-check-inline', item_label_class: 'form-check-label', class: 'row mb-3' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'col-sm-3 col-form-label pt-0'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
       ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal file input
-  config.wrappers :horizontal_file, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_file, class: 'row mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
     b.optional :minlength
     b.optional :readonly
     b.use :label, class: 'col-sm-3 col-form-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
+    end
+  end
+
+  # horizontal select input
+  config.wrappers :horizontal_select, class: 'row mb-3' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-select', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal multi select
-  config.wrappers :horizontal_multi_select, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_multi_select, class: 'row mb-3' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'col-sm-3 col-form-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |bb|
-        bb.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.wrapper class: 'd-flex flex-row justify-content-between align-items-center' do |bb|
+        bb.use :input, class: 'form-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
       end
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal range input
-  config.wrappers :horizontal_range, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_range, class: 'row mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :readonly
     b.optional :step
-    b.use :label, class: 'col-sm-3 col-form-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: 'col-sm-3 col-form-label pt-0'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-range', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
@@ -244,7 +263,7 @@ SimpleForm.setup do |config|
   # inline forms
   #
   # inline default_wrapper
-  config.wrappers :inline_form, tag: 'span', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :inline_form, class: 'col-12' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -252,140 +271,66 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: 'sr-only'
+    b.use :label, class: 'visually-hidden'
 
     b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :error, wrap_with: { class: 'invalid-feedback' }
+    b.optional :hint, wrap_with: { class: 'form-text' }
   end
 
   # inline input for boolean
-  config.wrappers :inline_boolean, tag: 'span', class: 'form-check mb-2 mr-sm-2', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :inline_boolean, class: 'col-12' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :label, class: 'form-check-label'
-    b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.wrapper :form_check_wrapper, class: 'form-check' do |bb|
+      bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'form-check-label'
+      bb.use :error, wrap_with: { class: 'invalid-feedback' }
+      bb.optional :hint, wrap_with: { class: 'form-text' }
+    end
   end
 
 
   # bootstrap custom forms
   #
-  # custom input for boolean
-  config.wrappers :custom_boolean, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
-    b.use :html5
-    b.optional :readonly
-    b.wrapper :form_check_wrapper, tag: 'div', class: 'custom-control custom-checkbox' do |bb|
-      bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      bb.use :label, class: 'custom-control-label'
-      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
-    end
-  end
-
   # custom input switch for boolean
-  config.wrappers :custom_boolean_switch, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :custom_boolean_switch, class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :form_check_wrapper, tag: 'div', class: 'custom-control custom-switch' do |bb|
-      bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      bb.use :label, class: 'custom-control-label'
+    b.wrapper :form_check_wrapper, tag: 'div', class: 'form-check form-switch' do |bb|
+      bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'form-check-label'
       bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      bb.use :hint, wrap_with: { class: 'form-text' }
     end
-  end
-
-  # custom input for radio buttons and check boxes
-  config.wrappers :custom_collection, item_wrapper_class: 'custom-control', item_label_class: 'custom-control-label', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
-    b.use :html5
-    b.optional :readonly
-    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
-      ba.use :label_text
-    end
-    b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
-  end
-
-  # custom input for inline radio buttons and check boxes
-  config.wrappers :custom_collection_inline, item_wrapper_class: 'custom-control custom-control-inline', item_label_class: 'custom-control-label', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
-    b.use :html5
-    b.optional :readonly
-    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
-      ba.use :label_text
-    end
-    b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
-  end
-
-  # custom file input
-  config.wrappers :custom_file, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
-    b.use :html5
-    b.use :placeholder
-    b.optional :maxlength
-    b.optional :minlength
-    b.optional :readonly
-    b.use :label
-    b.wrapper :custom_file_wrapper, tag: 'div', class: 'custom-file' do |ba|
-      ba.use :input, class: 'custom-file-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :label, class: 'custom-file-label'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    end
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
-  end
-
-  # custom multi select
-  config.wrappers :custom_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
-    b.use :html5
-    b.optional :readonly
-    b.use :label
-    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
-      ba.use :input, class: 'custom-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
-    end
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
-  end
-
-  # custom range input
-  config.wrappers :custom_range, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
-    b.use :html5
-    b.use :placeholder
-    b.optional :readonly
-    b.optional :step
-    b.use :label
-    b.use :input, class: 'custom-range', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
   end
 
 
   # Input Group - custom component
-  # see example app and config at https://github.com/rafaelfranca/simple_form-bootstrap
-  # config.wrappers :input_group, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
-  #   b.use :html5
-  #   b.use :placeholder
-  #   b.optional :maxlength
-  #   b.optional :minlength
-  #   b.optional :pattern
-  #   b.optional :min_max
-  #   b.optional :readonly
-  #   b.use :label
-  #   b.wrapper :input_group_tag, tag: 'div', class: 'input-group' do |ba|
-  #     ba.optional :prepend
-  #     ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
-  #     ba.optional :append
-  #   end
-  #   b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-  #   b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
-  # end
+  # see example app and config at https://github.com/heartcombo/simple_form-bootstrap
+  config.wrappers :input_group, class: 'mb-3' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'form-label'
+    b.wrapper :input_group_tag, class: 'input-group' do |ba|
+      ba.optional :prepend
+      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.optional :append
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    end
+    b.use :hint, wrap_with: { class: 'form-text' }
+  end
 
 
   # Floating Labels form
   #
   # floating labels default_wrapper
-  config.wrappers :floating_labels_form, tag: 'div', class: 'form-label-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :floating_labels_form, class: 'form-floating mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -395,18 +340,18 @@ SimpleForm.setup do |config|
     b.optional :readonly
     b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # custom multi select
-  config.wrappers :floating_labels_select, tag: 'div', class: 'form-label-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :floating_labels_select, class: 'form-floating mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :input, class: 'custom-select', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :input, class: 'form-select', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
 
@@ -423,18 +368,7 @@ SimpleForm.setup do |config|
     file:          :vertical_file,
     radio_buttons: :vertical_collection,
     range:         :vertical_range,
-    time:          :vertical_multi_select
+    time:          :vertical_multi_select,
+    select:        :vertical_select
   }
-
-  # enable custom form wrappers
-  # config.wrapper_mappings = {
-  #   boolean:       :custom_boolean,
-  #   check_boxes:   :custom_collection,
-  #   date:          :custom_multi_select,
-  #   datetime:      :custom_multi_select,
-  #   file:          :custom_file,
-  #   radio_buttons: :custom_collection,
-  #   range:         :custom_range,
-  #   time:          :custom_multi_select
-  # }
 end


### PR DESCRIPTION
This seems to change a few things, but I think it's okay:

| before | after |
|---------|--------|
| ![grafik](https://user-images.githubusercontent.com/5578100/120241581-58a9b580-c263-11eb-8e9a-5eacfbfb313c.png) | ![grafik](https://user-images.githubusercontent.com/5578100/120241600-5fd0c380-c263-11eb-96a7-6741390f52b2.png) |
| ![grafik](https://user-images.githubusercontent.com/5578100/120241608-65c6a480-c263-11eb-9f93-c0d8de1efb19.png) | ![grafik](https://user-images.githubusercontent.com/5578100/120241619-6b23ef00-c263-11eb-9814-d1dc3ebc518d.png) |

We'll also loose support for the following browsers:
 
>    Dropped Internet Explorer 10 and 11
>    Dropped Microsoft Edge < 16 (Legacy Edge)
>    Dropped Firefox < 60
>    Dropped Safari < 12
>    Dropped iOS Safari < 12
>    Dropped Chrome < 60

I did not test any of those browsers, but the app should still be usable. It might just look weird. (It *is* still usable with lynx, however.)
