### PR TITLE
feat: Add autofocus to barcode input

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -38,7 +38,7 @@
   %small
     Buy a drink by scanning a barcode: 
   = hidden_field_tag :authenticity_token, form_authenticity_token
-  %input{:name => "barcode"}
+  %input{:name => "barcode", :autofocus => ""}
 
 %hr
 


### PR DESCRIPTION
This change adds the autofocus field to the barcode input. In our testing we found out that this doesnt trigger the on-screen keyboard and helps using barcode scanners