### PR TITLE
Change routes to use POST Requests for payment actions

### DIFF
--- a/app/views/application/_bills.html.haml
+++ b/app/views/application/_bills.html.haml
@@ -1,7 +1,7 @@
 - [0.5,1,2,5,10,20,50].each do |amount|
   - path = deposit_user_path(@user, :amount => amount) if @user
   .col-12.col-sm-6.col-md-4.col-lg-3.col-xl-3.my-2
-    = link_to path || '#' do
+    = link_to path, method: :post || '#' do
       .card.bill-card.text-center
         .card-body
           = image_tag "euro-#{amount}.png", alt: show_amount(amount)

--- a/app/views/drinks/_drink.html.haml
+++ b/app/views/drinks/_drink.html.haml
@@ -1,7 +1,7 @@
 - path = buy_user_path(@user, :drink => drink.id) if @user
 
 .col-12.col-sm-4.col-md-3.col-lg-2.col-xl-2.my-2
-  = link_to(path || '#', :data => drink.active? ? {} : {confirm: "This drink is inactive. Do you really want to buy #{drink.name}?"}) do
+  = link_to(path || '#', data: drink.active? ? {} : {confirm: "This drink is inactive. Do you really want to buy #{drink.name}?"}, method: :post) do
     .card.drink-card.text-center
       .card-header
         .inner-header

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,8 @@ Mete::Application.routes.draw do
 
   get 'users/:id/deposit.json', to: redirect('api/v1/users/%{id}/deposit.json'), format: false
   get 'users/:id/payment.json', to: redirect('api/v1/users/%{id}/payment.json'), format: false
-  post 'users/:id/buy.json', to: redirect('api/v1/users/%{id}/buy.json'), format: false
+  get 'users/:id/buy.json', to: redirect('api/v1/users/%{id}/buy.json'), format: false
+  post 'users/:id/buy.json', to: redirect('api/v2/users/%{id}/buy.json'), format: false
   get 'users/:id/buy_barcode.json', to: redirect('api/v1/users/%{id}/buy_barcode.json'), format: false
 
   get 'users/stats.json', to: redirect('api/v1/users/stats.json'), format: false
@@ -45,6 +46,23 @@ Mete::Application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      resources :audits
+      resources :drinks
+      resources :barcodes
+      resources :users do
+        member do
+          get 'deposit'
+          get 'payment'
+          get 'buy'
+          post 'buy_barcode'
+        end
+        collection do
+          get 'stats'
+        end
+      end
+    end
+    
+    namespace :v2 do
       resources :audits
       resources :drinks
       resources :barcodes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Mete::Application.routes.draw do
 
   get 'users/:id/deposit.json', to: redirect('api/v1/users/%{id}/deposit.json'), format: false
   get 'users/:id/payment.json', to: redirect('api/v1/users/%{id}/payment.json'), format: false
-  get 'users/:id/buy.json', to: redirect('api/v1/users/%{id}/buy.json'), format: false
+  post 'users/:id/buy.json', to: redirect('api/v1/users/%{id}/buy.json'), format: false
   get 'users/:id/buy_barcode.json', to: redirect('api/v1/users/%{id}/buy_barcode.json'), format: false
 
   get 'users/stats.json', to: redirect('api/v1/users/stats.json'), format: false
@@ -33,9 +33,9 @@ Mete::Application.routes.draw do
   resources :users do
     resources :wrapped
     member do
-      get 'deposit'
-      get 'payment'
-      get 'buy'
+      post 'deposit'
+      post 'payment'
+      post 'buy'
       post 'buy_barcode'
     end
     collection do
@@ -50,9 +50,9 @@ Mete::Application.routes.draw do
       resources :barcodes
       resources :users do
         member do
-          get 'deposit'
-          get 'payment'
-          get 'buy'
+          post 'deposit'
+          post 'payment'
+          post 'buy'
           post 'buy_barcode'
         end
         collection do


### PR DESCRIPTION
Currents the Actions deposit, payment and buy use GET requests. This change adopts it to POST requests.

The API has gotten a new Version v2 which uses POST Requests.

Open Questions:
* Is this worth a new API version? Maybe just add the POST requests to the exisiting version