### PR TITLE
round the per-liter price

### DIFF
--- a/app/views/drinks/_drink.html.haml
+++ b/app/views/drinks/_drink.html.haml
@@ -12,7 +12,7 @@
         = show_amount drink.price
         %br
         - if drink.bottle_size?
-          = drink.price / drink.bottle_size
+          = sprintf('%.2f', drink.price / drink.bottle_size)
           €/L
         - else
           


### PR DESCRIPTION
I was using Mete the other day and found the per-liter price to take up a lot of space.
Example: drink costs 1 € for 330 ml -> liter price 3.030303[...] €/l.
I think 2 decimal places should be sufficient instead, so that's what I put. :)

Before:
![grafik](https://github.com/chaosdorf/mete/assets/6024426/db704818-1642-4539-bd5f-f3a719c0c2a6)
After:
![grafik](https://github.com/chaosdorf/mete/assets/6024426/5ed62a08-627e-4b7f-8676-228eaf22d744)
