### PR TITLE
feat: allow users to have an associated barcode

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,14 @@ class UsersController < ApplicationController
 
   # GET /users
   def index
+    if params[:barcode] != nil
+      @user = User.find_by(barcode: params[:barcode])
+      if @user
+        redirect_to @user
+      else
+        redirect_to users_url, :flash => { :error => "no user with that barcode found" }
+      end
+    end
     @users = User.order(active: :desc).order_by_name_asc
     # index.html.haml
   end
@@ -138,7 +146,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :avatar_provider, :avatar, :balance, :active, :audit, :redirect)
+    params.require(:user).permit(:name, :avatar_provider, :avatar, :balance, :active, :audit, :redirect, :barcode)
   end
 
   def warn_user_if_audit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,12 +2,20 @@
 
 class User < ApplicationRecord
   validates :name, presence: true
+  validates :barcode, uniqueness: { conditions: -> { where.not(barcode: nil) } }
 
   enum :avatar_provider, [ :gravatar, :webfinger ]
 
   scope :order_by_name_asc, -> {
     order(arel_table['name'].lower.asc)
   }
+
+  before_save do |user|
+    if user.barcode == ''
+      user.barcode = nil
+    end
+  end
+  
 
   after_save do |user|
     Audit.create! difference: user.balance - user.balance_before_last_save, drink: @purchased_drink, user: user.audit? ? user : nil

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -11,6 +11,7 @@
     = f.input :active
     = f.input :audit, hint: 'This will create detailed logs about what you buy and deposit. If you uncheck this box, all records will be deleted.'
     = f.input :redirect, hint: "Redirect after buying a drink?"
+    = f.input :barcode, hint: 'your barcode'
   .form-actions
     = f.button :submit, class: 'btn-primary'
 

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -5,6 +5,12 @@
   %li.nav-item
     = link_to 'new user', [:new, :user], class: "nav-link"
 
+.row
+  %form{:method => "GET"}
+    %small
+      Select a user by scanning a barcode:
+    %input{:name => "barcode", :autofocus => true, :inputMode => "none"}
+
 .user-filter
   .btn-group
     %a.btn{href: "#0", class: "user-filter-0"} #

--- a/db/migrate/20251228140735_add_barcode_to_user.rb
+++ b/db/migrate/20251228140735_add_barcode_to_user.rb
@@ -1,0 +1,6 @@
+class AddBarcodeToUser < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :barcode, :string, null: true
+    add_index :users, :barcode, unique: true, null: true
+  end
+end

--- a/db/migrate/20251228140735_add_barcode_to_user.rb
+++ b/db/migrate/20251228140735_add_barcode_to_user.rb
@@ -1,6 +1,6 @@
 class AddBarcodeToUser < ActiveRecord::Migration[8.0]
   def change
     add_column :users, :barcode, :string, null: true
-    add_index :users, :barcode, unique: true, null: true
+    add_index :users, :barcode, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2023_06_30_204356) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_28_140735) do
   create_table "audits", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.decimal "difference", precision: 20, scale: 2, default: "0.0"
@@ -46,5 +46,7 @@ ActiveRecord::Schema[8.0].define(version: 2023_06_30_204356) do
     t.boolean "audit", default: false
     t.boolean "redirect", default: true
     t.integer "avatar_provider", default: 0
+    t.string "barcode"
+    t.index ["barcode"], name: "index_users_on_barcode", unique: true
   end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -60,4 +60,16 @@ class UserTest < ActiveSupport::TestCase
     assert_respond_to u, :audit, "audit missing"
     assert_respond_to u, :redirect, "redirect missing"
   end
+
+  test "two users should't have the same barcode" do
+    user = User.new
+    user.name = "test"
+    user.barcode = "testbc"
+    user.save
+
+    user2 = User.new
+    user2.name = "test2"
+    user2.barcode = "testbc"
+    assert_equal user2.save, false, "two users with the same barcode could be created"
+  end
 end


### PR DESCRIPTION
This PR allows users to have an optional personal barcode so that they can quickly open their page using a [library card, iButton, nfc implant]. lucy hasn't done anything with rails before so it's sorry if this code is bad.

<img width="2040" height="1234" alt="image" src="https://github.com/user-attachments/assets/76e46cb9-bdeb-4e5f-bdd1-276aa85b74a8" />

<img width="1658" height="493" alt="image" src="https://github.com/user-attachments/assets/50c8d208-ec73-4aaa-9c14-6787d6198791" />
